### PR TITLE
Version number in minified version as well please?

### DIFF
--- a/js/jquery.gritter.min.js
+++ b/js/jquery.gritter.min.js
@@ -1,3 +1,13 @@
+/*
+ * Gritter for jQuery
+ * http://www.boedesign.com/
+ *
+ * Copyright (c) 2011 Jordan Boesch
+ * Dual licensed under the MIT and GPL licenses.
+ *
+ * Date: March 29, 2011
+ * Version: 1.7.1
+ */
 (function($){$.gritter={};$.gritter.options={position:'',fade_in_speed:'medium',fade_out_speed:1000,time:6000}
 $.gritter.add=function(params){try{return Gritter.add(params||{});}catch(e){var err='Gritter Error: '+e;(typeof(console)!='undefined'&&console.error)?console.error(err,params):alert(err);}}
 $.gritter.remove=function(id,params){Gritter.removeSpecific(id,params||{});}


### PR DESCRIPTION
It just makes it easier to track the versions even when using the minified version. jQuery follows this convention and I think its worth repeating.

That said, I don't know what your compression workflow looks like so it might be easier to leave off, but its just a nice to have.
