### PR TITLE
Before close callback

### DIFF
--- a/js/jquery.gritter.js
+++ b/js/jquery.gritter.js
@@ -168,6 +168,11 @@
 				Gritter._hoverState($(this), event.type);
 			});
 			
+			// Clicking (X) makes the perdy thing close
+			$(item).find('.gritter-close').click(function(){
+				Gritter.removeSpecific(number, {}, null, true);
+			});
+			
 			return number;
 	    
 		},
@@ -249,13 +254,7 @@
 				
 				// Show close button
 				e.find('.gritter-close').show();
-				
-				// Clicking (X) makes the perdy thing close
-				e.find('.gritter-close').click(function(){
-					var unique_id = e.attr('id').split('-')[2];
-					Gritter.removeSpecific(unique_id, {}, e, true);
-				});
-			
+						
 			}
 			// Remove the border styles and hide (X) close button when you mouse out
 			else {


### PR DESCRIPTION
I noticed that every time you hover over the notification a new click event is registered. 
For example when you hover over the notification 5 times and then click X to close, the removeSpecific (and thus_fade and before_close callback) are executed 5 times.
To fix this I simply moved the click binding from _hoverState to the add function.
