### PR TITLE
Stopped leaking global variables

### DIFF
--- a/js/jquery.gritter.js
+++ b/js/jquery.gritter.js
@@ -208,7 +208,7 @@
 		_fade: function(e, unique_id, params, unbind_events){
 
 			var params = params || {},
-				fade = (typeof(params.fade) != 'undefined') ? params.fade : true;
+				fade = (typeof(params.fade) != 'undefined') ? params.fade : true,
 				fade_out_speed = params.speed || this.fade_out_speed,
                 manual_close = unbind_events;
 


### PR DESCRIPTION
`fade_out_speed` and `manual_close` are global variables against my expected.
I fixed it.
