### PR TITLE
Add support for bower package manager

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,10 @@
 A small growl-like notification plugin for jQuery
 - http://boedesign.com/blog/2009/07/11/growl-for-jquery-gritter/
 
+## Installation
+
+    $ bower install jquery.gritter
+
 ## Change Log
 
 ### Changes in 1.7.4 (February 24, 2012)

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "jquery.gritter",
+  "version": "1.7.4",
+  "main": ["./js/jquery.gritter.js", "./css/jquery.gritter.css"],
+  "dependencies": {
+    "jquery": "~1.8.2"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "1.7.4",
   "main": ["./js/jquery.gritter.js", "./css/jquery.gritter.css"],
   "dependencies": {
-    "jquery": "~1.8.2"
+    "jquery": ">=1.8.2"
   }
 }


### PR DESCRIPTION
Hi,

Added support for bower package manager.

Visit http://bower.io for installation instructions.

After you have installed bower, you need to register this package:
bower install jquery.gritter git://github.com/jboesch/Gritter.git
