### PR TITLE
Patch to fix android bug which ignores background shorthand

### DIFF
--- a/css/jquery.gritter.css
+++ b/css/jquery.gritter.css
@@ -28,14 +28,14 @@
 	background:url('../images/ie-spacer.gif'); /* ie7/8 fix */ 
 }
 .gritter-top {
-	background:url(../images/gritter.png) no-repeat left -30px;
+	background: no-repeat left -30px;
 	height:10px;
 }
 .hover .gritter-top {
 	background-position:right -30px;
 }
 .gritter-bottom {
-	background:url(../images/gritter.png) no-repeat left bottom;
+	background: no-repeat left bottom;
 	height:8px;
 	margin:0;
 }
@@ -44,7 +44,7 @@
 }
 .gritter-item {
 	display:block;
-	background:url(../images/gritter.png) no-repeat left -40px;
+	background: no-repeat left -40px;
 	color:#eee;
 	padding:2px 11px 8px 11px;
 	font-size: 11px;
@@ -63,11 +63,10 @@
 	position:absolute;
 	top:5px;
 	left:3px;
-	background:url(../images/gritter.png) no-repeat left top;
+	background: no-repeat left top;
 	cursor:pointer;
 	width:30px;
 	height:30px;
-	text-indent:-9999em;
 }
 .gritter-title {
 	font-size:14px;
@@ -89,6 +88,15 @@
 	width:220px;
 	float:right;
 }
+
+/* fixes android bug */
+.gritter-item,
+.gritter-bottom,
+.gritter-top,
+.gritter-close {
+    background-image: url(../images/gritter.png);
+}
+
 /* for the light (white) version of the gritter notice */
 .gritter-light .gritter-item,
 .gritter-light .gritter-bottom,
@@ -100,3 +108,4 @@
 .gritter-light .gritter-title {
     text-shadow: none;
 }
+


### PR DESCRIPTION
I noticed that android 4.x displays nearly invisible notifications.
Tried useing the gritter-light class and that works, so I checked the differences and noticed that with explicit background-image for the default case it works.
using explicit background-image instead of shorthand so that android displays correctly
