### PR TITLE
allow image_html option

### DIFF
--- a/css/jquery.gritter.css
+++ b/css/jquery.gritter.css
@@ -76,7 +76,8 @@
 	display:block;
 	text-shadow:1px 1px 0 #000; /* Not supported by IE :( */
 }
-.gritter-image {
+.gritter-image,
+.gritter-custom-image {
 	width:48px;
 	height:48px;
 	float:left;

--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
 		<li>
 			<a href="#" id="add-without-image">Add notification without image</a>
 		</li>
+		<li>
+			<a href="#" id="add-custom-image">Add notification with custom HTML for the image</a>
+		</li>
         <li>
             <a href="#" id="add-gritter-light">Add a white notification</a>: has a 'gritter-light' class_name applied to it.
         </li>
@@ -161,6 +164,19 @@
 				title: 'This is a notice without an image!',
 				// (string | mandatory) the text inside the notification
 				text: 'This will fade out after a certain amount of time. Vivamus eget tincidunt velit. Cum sociis natoque penatibus et <a href="#" style="color:#ccc">magnis dis parturient</a> montes, nascetur ridiculus mus.'
+			});
+
+			return false;
+		});
+		
+		$('#add-custom-image').click(function(){
+
+			$.gritter.add({
+				// (string | mandatory) the heading of the notification
+				title: 'This is a notice with custom HTML in the image area!',
+				// (string | mandatory) the text inside the notification
+				text: 'This will fade out after a certain amount of time. Vivamus eget tincidunt velit. Cum sociis natoque penatibus et <a href="#" style="color:#ccc">magnis dis parturient</a> montes, nascetur ridiculus mus.',
+				image_html: '<div class="custom-image" style="height:100%; background:green; text-align:center">custom HTML</div>'
 			});
 
 			return false;

--- a/js/jquery.gritter.js
+++ b/js/jquery.gritter.js
@@ -108,6 +108,7 @@
 			var title = params.title, 
 				text = params.text,
 				image = params.image || '',
+				image_html = params.image_html || '',
 				sticky = params.sticky || false,
 				item_class = params.class_name || $.gritter.options.class_name,
 				position = $.gritter.options.position,
@@ -133,7 +134,12 @@
 			}
 			
 			var image_str = (image != '') ? '<img src="' + image + '" class="gritter-image" />' : '',
-				class_name = (image != '') ? 'gritter-with-image' : 'gritter-without-image';
+				class_name = (image != '' || image_html != '') ? 'gritter-with-image' : 'gritter-without-image';
+			
+			// Check for custom image html override. If it exists, insert it instead of our generated IMG tag.
+			if(image_html !== ''){
+				image_str = '<div class="gritter-custom-image">' + image_html + '</div>'
+			}
 			
 			// String replacements on the template
 			if(title){


### PR DESCRIPTION
Allow user to pass image_html in order to customize the image, if they
need special markup there.

An example use-case would be a user who needs to insert an icon
from a sprite sheet in that place, rather than in individual image file.
